### PR TITLE
add to terms of service for cambridge

### DIFF
--- a/app/views/sidebar/_tos_cambridge.html.haml
+++ b/app/views/sidebar/_tos_cambridge.html.haml
@@ -10,6 +10,9 @@
   I understand that as a volunteer, I have control over the dates and times of my work. The City of Cambridge is not responsible for scheduling my volunteer activities or monitoring my compliance with the guidelines. I affirm that I am not receiving any compensation or consideration for my participation, and I have read, understood, and freely and willingly agreed to the release and hold harmless provisions stated below.
 
 %p
+  When adopting a storm drain, residents are encouraged to get creative with the names they choose. However, please note that the City reserves the right to review and approve all storm drain names to ensure they are appropriate for public display. Names that are deemed offensive, inappropriate, or do not align with the City's values or Storm Stewards program goals may be subject to change. The City will reach out to residents for an alternative name if needed.
+
+%p
   I agree to release, waive, and forever discharge the City of Cambridge (“the City”) and the Commonwealth of Massachusetts ("the Commonwealth"), as well as their respective employees, departments, officers, and agents, from any and all actions, causes of action, claims, demands, damages, costs, loss of services, expenses and compensation claims or demands arising from accidents, illnesses, injuries, losses, destruction, or property damage directly or indirectly resulting from my participation in this activity.
 
 %p


### PR DESCRIPTION
From: Sushant Bajracharya <sushant.bajracharya@mysticriver.org>
Date: Mon, Sep 30, 2024 at 12:15 PM
Subject: Re: Adopt-A-Drain website
To: Jeff Korenstein <j.korenstein@gmail.com>
Cc: Alex Ball <ball.alex.509@gmail.com>

...

Also , I wanted to follow up on the city of Cambridge's requested to add the language to the adopt-a-drain website's terms of service section  which states  that states the City reserves the right to review and approve final names? We have our first case of names we do not feel are appropriate for the public and are asking a resident to rename.  
 

Storm Drain Naming Policy

When adopting a storm drain, residents are encouraged to get creative with the names they choose. However, please note that the City reserves the right to review and approve all storm drain names to ensure they are appropriate for public display. Names that are deemed offensive, inappropriate, or do not align with the City's values or Storm Stewards program goals may be subject to change. The City will reach out to residents for an alternative name if needed.



Please let me know what your thoughts are,